### PR TITLE
Change force_ssl settings and add protocol to mailer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,10 +37,6 @@ module Peoplefinder
       from:  config.support_email
     }
 
-    config.action_mailer.default_url_options = {
-        host: ENV['ACTION_MAILER_DEFAULT_URL']
-    }
-
     config.elastic_search_url = ENV['MOJ_PF_ES_URL']
 
     config.disable_communities = true
@@ -51,7 +47,12 @@ module Peoplefinder
 
     config.rack_timeout = (ENV['RACK_TIMEOUT'] || 14)
 
-    config.start_secure_session = (ENV['SSL_ON'] =~ /(true|yes|1)$/) == 0
+    config.force_ssl = (ENV['SSL_ON'] =~ /(true|yes|1)$/) == 0
+
+    config.action_mailer.default_url_options = {
+        host: ENV['ACTION_MAILER_DEFAULT_URL'],
+        protocol: (config.force_ssl ? 'https' : 'http')
+    }
 
     config.valid_login_domains = %w[
       digital.justice.gov.uk

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Peoplefinder
 
     config.rack_timeout = (ENV['RACK_TIMEOUT'] || 14)
 
-    config.force_ssl = (ENV['SSL_ON'] =~ /(true|yes|1)$/) == 0
+    config.force_ssl = ENV['SSL_ON'] != 'false'
 
     config.action_mailer.default_url_options = {
         host: ENV['ACTION_MAILER_DEFAULT_URL'],

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = {
     host: 'localhost',
-    port: 3000
+    port: 3000,
+    protocol: 'http'
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
    config.action_mailer.default_url_options = {
     host: 'localhost',
-    port: 3000
+    port: 3000,
+    protocol: 'http'
   }
 end


### PR DESCRIPTION
SSL has been forced from within the engine until now. This moves that responsibility to the wrapper and can later be removed from the engine.

Also all links in e-mails are now https when ssl is enforced.