### PR TITLE
Send a GA event when team notification changes

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -96,4 +96,13 @@ $(function(){
     sendEvent('.breadcrumbs a', 'click', 'profile-page', 'profile-page-breadcrumb-clicked', 'Clicked on a breadcrumb in a profile page');
   });
 
+  ifPage('edit-profile-page', function() {
+    $('.membership-subscribed-check-box').change(function(e) {
+      if (e.target.checked) {
+        ga('send', 'event', 'edit-profile-page', 'check', 'Check team updates');
+      } else {
+        ga('send', 'event', 'edit-profile-page', 'uncheck', 'Uncheck team updates');
+      }
+    });
+  });
 });


### PR DESCRIPTION
This relies on https://github.com/ministryofjustice/peoplefinder/pull/81 to work, but won't break without it, and can thus safely be merged at any time.